### PR TITLE
Add command line arguments and prompts for login info

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -4,3 +4,4 @@ source 'https://rubygems.org'
 gemspec
 
 gem "pry"
+gem "highline"

--- a/README.md
+++ b/README.md
@@ -20,7 +20,12 @@ Or install it yourself as:
 
 ## Usage
 
-TODO: Write usage instructions here
+### ProfanityFE
+
+Norn can be used easily with [ProfanityFE](https://github.com/ondreian/ProfanityFE), due to its ability to connect to arbitrary ports for the game stream.
+The Norn default console (`bin/console`) will prompt for user login information, which will login to the specified character.
+Launching Profanity to read from port 8383 (`ruby profanity.rb --port=8383`) will cause ProfanityFE to connect to Norn for the game stream.
+Norn's connection to ProfanityFE can be confirmed by executing `/i Room.title` inside ProfanityFE, which should return the title of the current room.
 
 ## Development
 
@@ -36,4 +41,3 @@ Bug reports and pull requests are welcome on GitHub at https://github.com/ondrei
 ## License
 
 The gem is available as open source under the terms of the [MIT License](http://opensource.org/licenses/MIT).
-

--- a/bin/console
+++ b/bin/console
@@ -57,6 +57,3 @@ Norn.connect(account: options[:account], password: options[:password], character
 # (If you use this, don't forget to add pry to your Gemfile!)
 require "pry"
 Pry.start
-
-require "irb"
-IRB.start(__FILE__)

--- a/bin/console
+++ b/bin/console
@@ -1,6 +1,55 @@
 #!/usr/bin/env ruby
 require "bundler/setup"
 require "norn"
+require "highline/import"
+require "optparse"
+
+options = {
+  :account => nil,
+  :password => nil,
+  :character => nil,
+  :game => "GS3"
+}
+OptionParser.new do |opts|
+  opts.banner = "Usage: console [options]"
+  opts.on("-uUSER", "--username=USER", "Username for login") do |user|
+    options[:account] = user
+  end
+  opts.on("-pPASSWORD", "--password=PASSWORD", "Password") do |pass|
+    options[:password] = pass
+  end
+  opts.on("-cCHAR", "--character=CHAR", "Character name for login") do |character|
+    options[:character] = character.capitalize
+  end
+  opts.on("-gGAME", "--game=GAME", "Game to log into") do |game|
+    options[:game] = game
+  end
+  opts.on( '-h', '--help', 'Display this screen' ) do
+     puts opts
+     exit
+   end
+end.parse!
+
+if !options[:account]
+  options[:account] = ask("Account name: ")
+end
+
+if !options[:password]
+  options[:password] = ask("Password: ") { |q| q.echo = "*" }
+end
+
+if !options[:character]
+  Norn::Handshake.new(account: options[:account], password: options[:password], game: options[:game]) { |characters|
+    choose do |menu|
+      menu.prompt = "Choose character: "
+      characters.list.each_key do |name|
+        menu.choice(name) { options[:character] = name}
+      end
+    end
+  }
+end
+
+Norn.connect(account: options[:account], password: options[:password], character: options[:character], game: options[:game])
 
 # You can add fixtures and/or initialization code here to make experimenting
 # with your gem easier. You can also use a different console, if you like.


### PR DESCRIPTION
This adds command line argument parsing and CLI prompts for logging into a character, which makes logging into a given character more user friendly.
`console` is also reduced to calling a single interactive terminal during operation.
This also adds usage instructions for Norn and ProfanityFE.
